### PR TITLE
Add auth proxying

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ CLIENT_PORT=9000
 CLIENT_API_URL=http://localhost:9000
 CLIENT_API_PROXY_URL=http://localhost:3000/graphql
 
+### Auth proxy settings
+CLIENT_AUTH_PROXY_URL=http://localhost:3001/authenticate
+
 ### New Relic
 NEW_RELIC_CLIENT_LICENSE_KEY=
 NEW_RELIC_CLIENT_APP_ID=

--- a/deployment/nginx.conf.template
+++ b/deployment/nginx.conf.template
@@ -10,6 +10,10 @@ http {
       proxy_pass ${CLIENT_API_PROXY_URL};
     }
 
+    location /auth {
+      proxy_pass ${CLIENT_AUTH_PROXY_URL};
+    }
+
     location / {
       root /usr/share/nginx/html;
       try_files $uri /index.html;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       CLIENT_PORT: ${CLIENT_PORT}
       CLIENT_API_URL: ${CLIENT_API_URL}
       CLIENT_API_PROXY_URL: "http://server:3000"
+      CLIENT_AUTH_PROXY_URL: "http://continuum-auth:3001"
       CONTINUUM_LOGIN_URL: ${CONTINUUM_LOGIN_URL}
     networks:
       - "infra_api"

--- a/scripts/build-config.sh
+++ b/scripts/build-config.sh
@@ -2,7 +2,7 @@
 
 CONFIG_FILENAME=$(find /usr/share/nginx/html/ -name "config.*.js")
 
-envsubst ' $${CLIENT_PORT} $${CLIENT_API_PROXY_URL} ' \
+envsubst ' $${CLIENT_PORT} $${CLIENT_API_PROXY_URL} $${CLIENT_AUTH_PROXY_URL}' \
   < /etc/nginx/nginx.conf.template \
   > /etc/nginx/nginx.conf \
   && cp $CONFIG_FILENAME config-temp.js \

--- a/webpack.parts.js
+++ b/webpack.parts.js
@@ -21,6 +21,11 @@ exports.devServer = () => ({
                 target: `${process.env.CLIENT_API_PROXY_URL}`,
                 changeOrigin: true,
             },
+            '/auth': {
+                target: `${process.env.CLIENT_AUTH_PROXY_URL}`,
+                pathRewrite: {'^/auth': ''},
+                changeOrigin: true
+            }
         },
     },
 });


### PR DESCRIPTION
Closes #32 

- Added proxying for authentication route to backend auth service in webpack
- Update nginx configuration and scripts/build-config.sh to use CLIENT_AUTH_PROXY_URL