### PR TITLE
flush promises when running gql query on dashboard

### DIFF
--- a/src/dashboard/components/Dashboard.test.tsx
+++ b/src/dashboard/components/Dashboard.test.tsx
@@ -8,7 +8,6 @@ import apolloWrapper from '../../../test-utils/apolloWrapper';
 import Dashboard from './Dashboard';
 import { getSubmissionsQuery } from '../graphql';
 import { MockedResponse } from '@apollo/react-testing';
-import { debug } from 'webpack';
 const generateMockQueryResponse = (subs: Submission[]): MockedResponse[] => {
     return [
         {
@@ -29,7 +28,7 @@ describe('Dashboard', (): void => {
     const originalError = console.error;
     beforeAll(() => {
         // This is horrible but necessary to prevent console error output which isn't to do with the test scenarios see: https://github.com/libero/reviewer-client/issues/69
-        console.error = (...args: unknown[]) => {
+        console.error = (...args: unknown[]): void => {
             if (/Warning.*not wrapped in act/.test(args[0] as string)) {
                 return;
             }
@@ -51,7 +50,7 @@ describe('Dashboard', (): void => {
     });
 
     it('should render the no-submissions page if there are no submissions', async (): Promise<void> => {
-        const { container, debug } = render(<Dashboard />, {
+        const { container } = render(<Dashboard />, {
             wrapper: combineWrappers(apolloWrapper(generateMockQueryResponse([])), routerWrapper(['/link-1'])),
         });
         // flush graphql fetch promise

--- a/src/dashboard/components/Dashboard.test.tsx
+++ b/src/dashboard/components/Dashboard.test.tsx
@@ -8,6 +8,7 @@ import apolloWrapper from '../../../test-utils/apolloWrapper';
 import Dashboard from './Dashboard';
 import { getSubmissionsQuery } from '../graphql';
 import { MockedResponse } from '@apollo/react-testing';
+import { debug } from 'webpack';
 const generateMockQueryResponse = (subs: Submission[]): MockedResponse[] => {
     return [
         {
@@ -25,6 +26,20 @@ const generateMockQueryResponse = (subs: Submission[]): MockedResponse[] => {
 
 describe('Dashboard', (): void => {
     afterEach(cleanup);
+    const originalError = console.error;
+    beforeAll(() => {
+        // This is horrible but necessary to prevent console error output which isn't to do with the test scenarios see: https://github.com/libero/reviewer-client/issues/69
+        console.error = (...args: unknown[]) => {
+            if (/Warning.*not wrapped in act/.test(args[0] as string)) {
+                return;
+            }
+            originalError.call(console, ...args);
+        };
+    });
+
+    afterAll(() => {
+        console.error = originalError;
+    });
 
     it('should render correctly', (): void => {
         expect(
@@ -36,13 +51,13 @@ describe('Dashboard', (): void => {
     });
 
     it('should render the no-submissions page if there are no submissions', async (): Promise<void> => {
-        const { findByText } = render(<Dashboard />, {
+        const { container, debug } = render(<Dashboard />, {
             wrapper: combineWrappers(apolloWrapper(generateMockQueryResponse([])), routerWrapper(['/link-1'])),
         });
         // flush graphql fetch promise
-        await setTimeout(() => {});
-        // const testElement = await findByText('new-system-1');
-        // expect(testElement).toBeInTheDocument();
+        await new Promise(resolve => setTimeout(resolve));
+        const testElement = await container.querySelector('.no-submissions');
+        expect(testElement).toBeInTheDocument();
     });
 
     it('should render the standard dashboard page if there are submissions', async (): Promise<void> => {
@@ -51,12 +66,12 @@ describe('Dashboard', (): void => {
             title: 'Effects of Caffeine on Software Developers',
             updated: Date.now(),
         };
-        const { findByText } = render(<Dashboard />, {
+        const { container } = render(<Dashboard />, {
             wrapper: combineWrappers(apolloWrapper(generateMockQueryResponse([sampleSub])), routerWrapper(['/link-1'])),
         });
         // flush graphql fetch promise
-        await setTimeout(() => {});
-        // const testElement = await findByText('Submissions');
-        // expect(testElement).toBeInTheDocument();
+        await new Promise(resolve => setTimeout(resolve));
+        const testElement = await container.querySelector('.dashboard');
+        expect(testElement).toBeInTheDocument();
     });
 });

--- a/src/dashboard/components/Dashboard.test.tsx
+++ b/src/dashboard/components/Dashboard.test.tsx
@@ -23,7 +23,7 @@ const generateMockQueryResponse = (subs: Submission[]): MockedResponse[] => {
     ];
 };
 
-describe('Dashboard', (): void => {
+describe.skip('Dashboard', (): void => {
     afterEach(cleanup);
 
     it('should render correctly', (): void => {

--- a/src/dashboard/components/Dashboard.test.tsx
+++ b/src/dashboard/components/Dashboard.test.tsx
@@ -39,6 +39,8 @@ describe('Dashboard', (): void => {
         const { findByText } = render(<Dashboard />, {
             wrapper: combineWrappers(apolloWrapper(generateMockQueryResponse([])), routerWrapper(['/link-1'])),
         });
+        // flush graphql fetch promise
+        await setTimeout(() => {});
         const testElement = await findByText('new-system-1');
         expect(testElement).toBeInTheDocument();
     });
@@ -52,6 +54,8 @@ describe('Dashboard', (): void => {
         const { findByText } = render(<Dashboard />, {
             wrapper: combineWrappers(apolloWrapper(generateMockQueryResponse([sampleSub])), routerWrapper(['/link-1'])),
         });
+        // flush graphql fetch promise
+        await setTimeout(() => {});
         const testElement = await findByText('Submissions');
         expect(testElement).toBeInTheDocument();
     });

--- a/src/dashboard/components/Dashboard.test.tsx
+++ b/src/dashboard/components/Dashboard.test.tsx
@@ -41,7 +41,7 @@ describe('Dashboard', (): void => {
         });
         // flush graphql fetch promise
         await setTimeout(() => {});
-        const testElement = await findByText('testdiv');
+        const testElement = await findByText('new-system-1');
         expect(testElement).toBeInTheDocument();
     });
 

--- a/src/dashboard/components/Dashboard.test.tsx
+++ b/src/dashboard/components/Dashboard.test.tsx
@@ -41,8 +41,8 @@ describe('Dashboard', (): void => {
         });
         // flush graphql fetch promise
         await setTimeout(() => {});
-        const testElement = await findByText('new-system-1');
-        expect(testElement).toBeInTheDocument();
+        // const testElement = await findByText('new-system-1');
+        // expect(testElement).toBeInTheDocument();
     });
 
     it('should render the standard dashboard page if there are submissions', async (): Promise<void> => {
@@ -56,7 +56,7 @@ describe('Dashboard', (): void => {
         });
         // flush graphql fetch promise
         await setTimeout(() => {});
-        const testElement = await findByText('Submissions');
-        expect(testElement).toBeInTheDocument();
+        // const testElement = await findByText('Submissions');
+        // expect(testElement).toBeInTheDocument();
     });
 });

--- a/src/dashboard/components/Dashboard.test.tsx
+++ b/src/dashboard/components/Dashboard.test.tsx
@@ -23,7 +23,7 @@ const generateMockQueryResponse = (subs: Submission[]): MockedResponse[] => {
     ];
 };
 
-describe.skip('Dashboard', (): void => {
+describe('Dashboard', (): void => {
     afterEach(cleanup);
 
     it('should render correctly', (): void => {
@@ -41,7 +41,7 @@ describe.skip('Dashboard', (): void => {
         });
         // flush graphql fetch promise
         await setTimeout(() => {});
-        const testElement = await findByText('new-system-1');
+        const testElement = await findByText('testdiv');
         expect(testElement).toBeInTheDocument();
     });
 

--- a/src/dashboard/components/Dashboard.tsx
+++ b/src/dashboard/components/Dashboard.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { Link, withRouter } from 'react-router-dom';
 import { useQuery, useMutation } from '@apollo/react-hooks';
+import { useTranslation } from 'react-i18next';
 import { Button, Paragraph } from '../../ui/atoms';
 import SubmissionList from './SubmissionList';
 import { getSubmissionsQuery, startSubmissionMutation } from '../graphql';
 import { ExecutionResult } from 'graphql';
+import NoSubmissions from './NoSubmissions';
 
 const Dashboard = withRouter(
     (): JSX.Element => {
@@ -18,15 +20,16 @@ const Dashboard = withRouter(
                 });
             },
         });
+        const { t } = useTranslation();
 
         if (!loading && data.getSubmissions.length === 0) {
-            return <div>testdiv</div>;
+            return <NoSubmissions />;
         } else {
             return (
                 <div className="dashboard main-content--centered">
                     <div className="dashboard__button_container">
                         <Button type="primary" onClick={(): Promise<ExecutionResult> => startSubmission()}>
-                            new-submission
+                            {t('dashboard:new-submission')}
                         </Button>
                     </div>
                     {loading ? 'loading' : <SubmissionList submissions={data.getSubmissions} />}

--- a/src/dashboard/components/Dashboard.tsx
+++ b/src/dashboard/components/Dashboard.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import { Link, withRouter } from 'react-router-dom';
 import { useQuery, useMutation } from '@apollo/react-hooks';
-import { useTranslation } from 'react-i18next';
 import { Button, Paragraph } from '../../ui/atoms';
 import SubmissionList from './SubmissionList';
 import { getSubmissionsQuery, startSubmissionMutation } from '../graphql';
 import { ExecutionResult } from 'graphql';
-import NoSubmissions from './NoSubmissions';
 
 const Dashboard = withRouter(
     (): JSX.Element => {
@@ -20,16 +18,15 @@ const Dashboard = withRouter(
                 });
             },
         });
-        const { t } = useTranslation();
 
         if (!loading && data.getSubmissions.length === 0) {
-            return <NoSubmissions />;
+            return <div>testdiv</div>;
         } else {
             return (
                 <div className="dashboard main-content--centered">
                     <div className="dashboard__button_container">
                         <Button type="primary" onClick={(): Promise<ExecutionResult> => startSubmission()}>
-                            {t('dashboard:new-submission')}
+                            new-submission
                         </Button>
                     </div>
                     {loading ? 'loading' : <SubmissionList submissions={data.getSubmissions} />}


### PR DESCRIPTION
fixes #69 

Flush promises so we don't get jsdom errors from graphql fetches in unit tests.