### PR TITLE
Check out Git submodules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+        with:
+          submodules: true
       - uses: actions/cache@v1
         with:
           path: node_modules
@@ -26,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+        with:
+          submodules: true
       - uses: actions/cache@v1
         with:
           path: node_modules
@@ -49,6 +53,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+        with:
+          submodules: true
       - uses: actions/cache@v1
         with:
           path: node_modules


### PR DESCRIPTION
Still part of https://github.com/libero/publisher/issues/310 as a follow-up of https://github.com/libero/reviewer-client/pull/73. Compare https://github.com/libero/article-store/blob/master/.github/workflows/ci.yml#L93-L94

https://github.com/libero/reviewer-client/runs/375261132 failed because `.scripts` is not checked out by default by the `actions/checkout` Github Action.