### PR TITLE
move hook above conditional render to prevent hook order issue

### DIFF
--- a/src/core/components/NavBar.tsx
+++ b/src/core/components/NavBar.tsx
@@ -31,6 +31,7 @@ const menuItems = [
 ];
 
 const NavBar = (): JSX.Element => {
+    const { loading, data } = useQuery<GetCurrentUser>(getCurrentUserQuery);
     const { isAuthenticated } = useAppContext();
     if (!isAuthenticated) {
         return (
@@ -39,7 +40,6 @@ const NavBar = (): JSX.Element => {
             </AppBar>
         );
     }
-    const { loading, data } = useQuery<GetCurrentUser>(getCurrentUserQuery);
     return (
         <AppBar>
             <BurgerMenu items={menuItems} />


### PR DESCRIPTION
Closes #105

The second hook was after a terminating conditional so it was running the first time with out the hook being called so when it re-rendered after login the hook order had changed. Something we need to look out for in the future.