### PR TITLE
Remove the inclusion of credentials

### DIFF
--- a/config/reviewer-mocks/config.example.json
+++ b/config/reviewer-mocks/config.example.json
@@ -1,5 +1,4 @@
 {
-    "port": 3003,
     "login_return_url": "http://localhost:9000/login",
     "continuum_jwt_secret": "some_secret_from_journal",
     "continuum_return_url": "http://localhost:9000/auth-redirect",

--- a/src/core/utils/createApolloClient.ts
+++ b/src/core/utils/createApolloClient.ts
@@ -11,7 +11,12 @@ import { createUploadLink } from 'apollo-upload-client';
 export default (host: string): ApolloClient<unknown> => {
     const apiLink = createUploadLink({
         uri: `${host}/graphql`, // use https for secure endpoint,
-        credentials: 'include',
+        // Adding the line below causes logs of CORS issues which prevents
+        // the dashboard from being rendered. This needs reinstating along
+        // with adding headers for Access-Control-Allow-Origin
+        //
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSNotSupportingCredentials
+        // credentials: 'include',
     });
     const token = getToken();
     const authLink = setContext((_, { headers }) => {


### PR DESCRIPTION
Adding the `credential` line causes logs of CORS issues which prevents the dashboard from being rendered. This needs reinstating along with adding headers for Access-Control-Allow-Origin
   
see: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSNotSupportingCredentials

---
Linked to https://github.com/libero/reviewer/issues/687
        