### PR TITLE
Pull fresh token from storage

### DIFF
--- a/deployment/nginx.conf.template
+++ b/deployment/nginx.conf.template
@@ -10,6 +10,9 @@ http {
 
     location /graphql {
       proxy_pass ${CLIENT_API_PROXY_URL};
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
     }
 
     location /auth/ {

--- a/src/core/utils/createApolloClient.ts
+++ b/src/core/utils/createApolloClient.ts
@@ -18,13 +18,12 @@ export default (host: string): ApolloClient<unknown> => {
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSNotSupportingCredentials
         // credentials: 'include',
     });
-    const token = getToken();
     const authLink = setContext((_, { headers }) => {
         // return the headers to the context so httpLink can read them
         return {
             headers: {
                 ...headers,
-                authorization: token ? `Bearer ${token}` : '',
+                authorization: getToken() ? `Bearer ${getToken()}` : '',
             },
         };
     });
@@ -58,7 +57,7 @@ export default (host: string): ApolloClient<unknown> => {
             reconnect: true,
             connectionParams: {
                 headers: {
-                    authorization: token ? `Bearer ${token}` : '',
+                    authorization: getToken() ? `Bearer ${getToken()}` : '',
                 },
             },
         },


### PR DESCRIPTION
The token is currently set in App.tsx via a useEffect that reads the URL for a token. During this process, the app renders and so initialises the apollo client, and this can happen before the token is committed to local storage. 

Depending on the timing of this step, the token value is assigned to a variable (see here https://github.com/libero/reviewer-client/blob/35bdfa68c3c2c4479b3e46a4a0087ae6c253620d/src/core/utils/createApolloClient.ts#L21)

This can result in the token being null when it actually isn't.