### PR TITLE
709 - Add max supporting files reached message when max uploaded

### DIFF
--- a/src/core/locales/en/wizard-form.json
+++ b/src/core/locales/en/wizard-form.json
@@ -20,5 +20,8 @@
     "second-cosubmission-toggle-prefix": "Would you like to ",
     "second-cosubmission-toggle-link": "add another",
     "second-cosubmission-toggle-suffix": " co-submission?"
+  },
+  "files": {
+    "supporting-files-max": "Maximum 10 supporting files"
   }
 }

--- a/src/initial-submission/components/FileDetailsForm.test.tsx
+++ b/src/initial-submission/components/FileDetailsForm.test.tsx
@@ -479,5 +479,26 @@ describe('File Details Form', (): void => {
                 );
             });
         });
+        it('displays max files message when max files is reached', async (): Promise<void> => {
+            const { container, getByText } = render(
+                <FileDetailsForm initialValues={{ id: 'test', updated: Date.now(), articleType: '' }} />,
+                {
+                    wrapper: routerWrapper(),
+                },
+            );
+
+            expect(() => getByText('files.supporting-files-max')).toThrow();
+
+            const file = new File(['§§§'], 'supercoolfile1.png', { type: 'image/png' });
+            const fileInput = container.querySelector('.multifile-upload__input');
+
+            Object.defineProperty(fileInput, 'files', {
+                value: Array(maxSupportingFiles).fill(file),
+            });
+
+            await act(async () => await fireEvent.change(fileInput));
+
+            expect(getByText('files.supporting-files-max')).toBeInTheDocument();
+        });
     });
 });

--- a/src/initial-submission/components/FileDetailsForm.tsx
+++ b/src/initial-submission/components/FileDetailsForm.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import { useMutation, useSubscription } from '@apollo/react-hooks';
+import { useTranslation } from 'react-i18next';
 import { CoverLetter, FileUpload, MultiFileUpload } from '../../ui/molecules';
 import { FileState } from '../../ui/molecules/MultiFileUpload';
 import {
@@ -32,6 +33,7 @@ interface Props {
 }
 
 const FileDetailsForm = ({ initialValues }: Props): JSX.Element => {
+    const { t } = useTranslation('wizard-form');
     const { files } = initialValues;
     const { register, watch } = useForm({
         defaultValues: {
@@ -267,6 +269,7 @@ const FileDetailsForm = ({ initialValues }: Props): JSX.Element => {
                     onDelete={(): void => {}}
                     files={supportingFilesStatus}
                     disableUpload={supportingUploadDisabled || filesStoredCount === maxSupportingFiles}
+                    extraMessage={filesStoredCount === maxSupportingFiles && t('files.supporting-files-max')}
                 />
             </div>
         </div>

--- a/src/initial-submission/components/FileDetailsForm2.test.tsx
+++ b/src/initial-submission/components/FileDetailsForm2.test.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useRef, DependencyList } from 'react';
 import FileDetailsForm from './FileDetailsForm';
 import routerWrapper from '../../../test-utils/routerWrapper';
 
-const mutationMock = jest.fn();
+const mutationMock = jest.fn(() => new Promise(() => {}));
 let subscriptionData: {};
 
 jest.mock('../hooks/useAutoSave', () => (cb: () => void, deps: DependencyList): void => {

--- a/src/ui/molecules/MultiFileUpload.test.tsx
+++ b/src/ui/molecules/MultiFileUpload.test.tsx
@@ -134,6 +134,19 @@ describe('MultiFileUpload', () => {
         expect(container.querySelector('.multifile-upload__input')).toBeNull();
     });
 
+    it('displays extra message when passed extraMessage prop', (): void => {
+        const { getByText } = render(
+            <MultiFileUpload onUpload={jest.fn()} onDelete={jest.fn()} extraMessage="test message" />,
+        );
+        expect(getByText('test message')).toBeInTheDocument();
+    });
+
+    it('displays extra message when passed extraMessage prop', (): void => {
+        const { container } = render(<MultiFileUpload onUpload={jest.fn()} onDelete={jest.fn()} />);
+
+        expect(container.querySelector('.multifile-upload__extra-message')).toBeNull();
+    });
+
     describe('FileItem', (): void => {
         it('shows the correct UploadProgress for each item', () => {
             const { container } = render(

--- a/src/ui/molecules/MultiFileUpload.tsx
+++ b/src/ui/molecules/MultiFileUpload.tsx
@@ -24,6 +24,7 @@ interface Props {
     onUpload: (files: FileList) => void;
     onDelete: (index: number) => void;
     disableUpload?: boolean;
+    extraMessage?: string;
 }
 
 interface FileItemProps extends FileState {
@@ -78,7 +79,7 @@ const FileItem = ({ uploadInProgress, error, fileStored, onDelete }: FileItemPro
     );
 };
 
-const MultiFileUpload = ({ files = [], onUpload, onDelete, disableUpload }: Props): JSX.Element => {
+const MultiFileUpload = ({ files = [], onUpload, onDelete, disableUpload, extraMessage }: Props): JSX.Element => {
     const { t } = useTranslation('ui');
     return (
         <div className="multifile-upload">
@@ -111,6 +112,7 @@ const MultiFileUpload = ({ files = [], onUpload, onDelete, disableUpload }: Prop
                     />
                 </Fragment>
             )}
+            {extraMessage ? <span className="multifile-upload__extra-message">{extraMessage}</span> : null}
         </div>
     );
 };

--- a/src/ui/styles/MultiFileUpload.scss
+++ b/src/ui/styles/MultiFileUpload.scss
@@ -1,11 +1,14 @@
 @import '../../core/styles/typography';
 
+$messageColour: rgb(98,159,67);
+
 .multifile-upload__input {
     visibility: hidden;
 }
 
 .multifile-upload__upload-list {
   border: 0.063rem solid $borderColour;
+  margin-bottom: 1.5rem;
 }
 
 .multifile-upload__upload-list-item {
@@ -30,7 +33,6 @@
 }
 
 .multifile-upload__label {
-  margin-top: 1.5rem;
   display: inline-block;
 }
 
@@ -65,4 +67,9 @@
 
 .multifile-upload__file-status--error {
   color: $colourError;
+}
+
+.multifile-upload__extra-message {
+  color: $messageColour;
+  font-size: $fontSizeSmall;
 }


### PR DESCRIPTION
closes libero/reviewer#709

Adds a message when the user reaches the maximum allowed supporting files.