### PR TITLE
780 - supporting upload cache

### DIFF
--- a/src/initial-submission/components/FileDetailsForm.tsx
+++ b/src/initial-submission/components/FileDetailsForm.tsx
@@ -312,6 +312,7 @@ const FileDetailsForm = ({ initialValues }: Props): JSX.Element => {
                     onUpload={onSupportingFilesUpload}
                     onDelete={deleteSupportingFileCallback}
                     files={supportingFilesStatus}
+                    disableDelete={supportingUploadDisabled}
                     disableUpload={supportingUploadDisabled || filesStoredCount === maxSupportingFiles}
                     extraMessage={filesStoredCount === maxSupportingFiles && t('files.supporting-files-max')}
                 />

--- a/src/initial-submission/components/FileDetailsForm.tsx
+++ b/src/initial-submission/components/FileDetailsForm.tsx
@@ -62,7 +62,6 @@ const FileDetailsForm = ({ initialValues }: Props): JSX.Element => {
                 query: getSubmissionQuery,
                 variables: { id: initialValues.id },
             });
-            console.log(uploadSupportingFile);
             getSubmission.files.supportingFiles.push(uploadSupportingFile);
             cache.writeQuery({
                 query: getSubmissionQuery,

--- a/src/initial-submission/components/FileDetailsForm.tsx
+++ b/src/initial-submission/components/FileDetailsForm.tsx
@@ -56,7 +56,20 @@ const FileDetailsForm = ({ initialValues }: Props): JSX.Element => {
     const [supportingFilesStatus, setSupportingFilesStatus] = useState<FileState[]>(getInitialSupportingFiles());
     const [saveCallback] = useMutation(saveFilesPageMutation);
     const [uploadManuscriptFile] = useMutation(uploadManuscriptMutation);
-    const [uploadSupportingFile] = useMutation(uploadSupportingFileMutation);
+    const [uploadSupportingFile] = useMutation(uploadSupportingFileMutation, {
+        update(cache, { data: { uploadSupportingFile } }) {
+            const { getSubmission } = cache.readQuery({
+                query: getSubmissionQuery,
+                variables: { id: initialValues.id },
+            });
+            console.log(uploadSupportingFile);
+            getSubmission.files.supportingFiles.push(uploadSupportingFile);
+            cache.writeQuery({
+                query: getSubmissionQuery,
+                data: { getSubmission: getSubmission },
+            });
+        },
+    });
     const [deleteSupportingFile] = useMutation(deleteSupportingFileMutation, {
         update(cache, { data: { deleteSupportingFile } }) {
             const { getSubmission } = cache.readQuery({

--- a/src/ui/molecules/MultiFileUpload.test.tsx
+++ b/src/ui/molecules/MultiFileUpload.test.tsx
@@ -147,6 +147,34 @@ describe('MultiFileUpload', () => {
         expect(container.querySelector('.multifile-upload__extra-message')).toBeNull();
     });
 
+    it('does not display FileItem delete icons if disableDelete is true', (): void => {
+        const { container, rerender } = render(
+            <MultiFileUpload
+                files={[
+                    { uploadInProgress: { fileName: 'File 1.pdf', progress: 42 }, error: 'server' },
+                    { fileStored: { fileName: 'File 2.pdf', id: 'bob' } },
+                    { fileStored: { fileName: 'File 3.pdf', id: 'mel' } },
+                ]}
+                onUpload={jest.fn()}
+                onDelete={jest.fn()}
+            />,
+        );
+        expect(container.querySelectorAll('.multifile-upload__delete')).toHaveLength(3);
+        rerender(
+            <MultiFileUpload
+                files={[
+                    { uploadInProgress: { fileName: 'File 1.pdf', progress: 42 }, error: 'server' },
+                    { fileStored: { fileName: 'File 2.pdf', id: 'bob' } },
+                    { fileStored: { fileName: 'File 3.pdf', id: 'mel' } },
+                ]}
+                disableDelete={true}
+                onUpload={jest.fn()}
+                onDelete={jest.fn()}
+            />,
+        );
+        expect(container.querySelectorAll('.multifile-upload__delete')).toHaveLength(0);
+    });
+
     describe('FileItem', (): void => {
         it('shows the correct UploadProgress for each item', () => {
             const { container } = render(

--- a/src/ui/molecules/MultiFileUpload.tsx
+++ b/src/ui/molecules/MultiFileUpload.tsx
@@ -24,15 +24,17 @@ interface Props {
     files?: FileState[];
     onUpload: (files: FileList) => void;
     onDelete: (fileId: string) => void;
+    disableDelete?: boolean;
     disableUpload?: boolean;
     extraMessage?: string;
 }
 
 interface FileItemProps extends FileState {
     onDelete: (fileId: string) => void;
+    disableDelete?: boolean;
 }
 
-const FileItem = ({ uploadInProgress, error, fileStored, onDelete }: FileItemProps): JSX.Element => {
+const FileItem = ({ uploadInProgress, error, fileStored, onDelete, disableDelete }: FileItemProps): JSX.Element => {
     const { t } = useTranslation('ui');
     const status = useMemo(() => {
         if (error && status !== 'ERROR') {
@@ -71,7 +73,7 @@ const FileItem = ({ uploadInProgress, error, fileStored, onDelete }: FileItemPro
                     </span>
                 ) : null}
             </span>
-            {status === 'COMPLETE' || status === 'ERROR' ? (
+            {!disableDelete && (status === 'COMPLETE' || status === 'ERROR') ? (
                 <div>
                     <Delete className="multifile-upload__delete" onClick={(): void => onDelete(fileStored.id)} />
                 </div>
@@ -80,14 +82,21 @@ const FileItem = ({ uploadInProgress, error, fileStored, onDelete }: FileItemPro
     );
 };
 
-const MultiFileUpload = ({ files = [], onUpload, onDelete, disableUpload, extraMessage }: Props): JSX.Element => {
+const MultiFileUpload = ({
+    files = [],
+    onUpload,
+    onDelete,
+    disableUpload,
+    disableDelete,
+    extraMessage,
+}: Props): JSX.Element => {
     const { t } = useTranslation('ui');
     return (
         <div className="multifile-upload">
             {files.length ? (
                 <div className="multifile-upload__upload-list">
                     {files.map((file, index) => {
-                        return <FileItem key={index} {...file} onDelete={onDelete} />;
+                        return <FileItem key={index} {...file} onDelete={onDelete} disableDelete={disableDelete} />;
                     })}
                 </div>
             ) : null}

--- a/src/ui/styles/MultiFileUpload.scss
+++ b/src/ui/styles/MultiFileUpload.scss
@@ -30,6 +30,7 @@ $messageColour: rgb(98,159,67);
 
 .multifile-upload__delete {
   color: $colourTextSecondary;
+  cursor: pointer;
 }
 
 .multifile-upload__label {


### PR DESCRIPTION
- Update Submission cache when uploading a supporting file (fixes bug with navigating between steps)
- Add pointer cursor styling to delete icon.
- Disable delete icon when upload supporting file is in progress to prevent incorrect state updates when uploads return response.

Closes libero/reviewer#780