### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 The client for "libero reviewer".
 
+<details>
+
+<summary>Requirements</summary>
+
+- [Docker]
+- [GNU Make]
+- [Node.js]
+
+</details>
+
+The project contains a [Makefile] which uses [Docker] for development.
+
 ## Running the client
 
 1. `make setup`
@@ -44,4 +56,3 @@ The compose files use `liberoadmin/reviewer-mocks:latest`.
     libero/reviewer-mocks:local \
     liberoadmin/reviewer-mocks:latest
   ```
-  

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The client for "libero reviewer".
 - [Docker]
 - [GNU Make]
 - [Node.js]
-
+- [timeout] (on MacOSX this can be obtained with `brew install coreutils`)
 </details>
 
 The project contains a [Makefile] which uses [Docker] for development.
@@ -56,3 +56,8 @@ The compose files use `liberoadmin/reviewer-mocks:latest`.
     libero/reviewer-mocks:local \
     liberoadmin/reviewer-mocks:latest
   ```
+
+[Docker]: https://www.docker.com/
+[Makefile]: Makefile
+[Node.js]: https://nodejs.org/
+[timeout]: http://man7.org/linux/man-pages/man1/timeout.1.html

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The compose files use `liberoadmin/reviewer-mocks:latest`.
   ```
 
 [Docker]: https://www.docker.com/
+[GNU Make]: https://www.gnu.org/software/make/
 [Makefile]: Makefile
 [Node.js]: https://nodejs.org/
 [timeout]: http://man7.org/linux/man-pages/man1/timeout.1.html


### PR DESCRIPTION
Adds a Requirements section to the README. Driver was the need to `brew install coreutils` to get `timeout` working (used in `make start_test`).

Uses references to links rather than inline links for ease of future link management.