### PR TITLE
Speed up Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,30 +7,9 @@ COPY LICENSE .
 HEALTHCHECK --interval=5s --timeout=1s \
 	CMD echo -e "GET /health\n\n" | nc localhost:9000
 
-#
-# Stage: Production NPM install
-#
-FROM node AS yarn-prod
-
 COPY package.json \
     yarn.lock \
-    ./
-
-RUN yarn install --production
-
-#
-# Stage: Development NPM install
-#
-FROM yarn-prod AS yarn-dev
-
-RUN yarn install
-
-#
-# Stage: Development environment
-#
-FROM node AS dev
-
-COPY globals.d.ts \
+    globals.d.ts \
     index.ejs \
     index.tsx \
     .eslintrc.js \
@@ -42,20 +21,26 @@ COPY globals.d.ts \
     tsconfig.json \
     webpack.config.js \
     ./
-COPY --from=yarn-dev /app/ .
 COPY tests/ tests/
 COPY test-utils/ test-utils/
 COPY src/ src/
 COPY webpack/ webpack/
 
-CMD ["yarn", "run", "start:dev"]
+RUN yarn install
 
 #
 # Stage: Production build
 #
-FROM dev AS build-prod
+FROM node AS build-prod
 
 RUN yarn run build
+
+#
+# Stage: Development environment
+#
+FROM node AS dev
+
+CMD ["yarn", "run", "start:dev"]
 
 #
 # Stage: Production environment
@@ -64,11 +49,8 @@ FROM nginx:stable-alpine@sha256:0dfc8450deb8c7f06fbaac27e453ac3262df7d3a93639c4e
 
 LABEL maintainer="eLife Reviewer Product Team <reviewer-product@elifesciences.org>"
 
-COPY --from=yarn-prod /app/ .
-COPY --from=build-prod /app/dist/ dist/
-COPY config/nginx/nginx.conf /etc/nginx/nginx.conf
-
 HEALTHCHECK --interval=5s --timeout=1s \
 	CMD echo -e "GET /health\n\n" | nc localhost:80
 
-CMD ["nginx", "-g", "daemon off;"]
+COPY config/nginx/nginx.conf /etc/nginx/nginx.conf
+COPY --from=build-prod /app/dist dist


### PR DESCRIPTION
- avoid running yarn install twice (6ish instead of 8+ minutes)
- only copy dist instead of all of app (30MB instead of 100MB image)