### PR TITLE
Enable selectable tests with env var TEST_FIXTURE

### DIFF
--- a/browsertests.Dockerfile
+++ b/browsertests.Dockerfile
@@ -5,4 +5,4 @@ WORKDIR /app
 COPY tests tests
 COPY test-utils test-utils
 
-ENTRYPOINT [ "testcafe", "chromium:headless  --no-sandbox --disable-dev-shm-usage", "tests/**/*.browser.ts" ]
+ENTRYPOINT [ "./tests/test-entry.sh" ]

--- a/tests/browser-tests/Minimal.browser.ts
+++ b/tests/browser-tests/Minimal.browser.ts
@@ -1,0 +1,10 @@
+import { LoginPage } from '../page-objects';
+import { BASE_URL } from '../../test-utils/baseUrl';
+
+fixture`Minimal`.page`${BASE_URL}`;
+
+test('landing page is rendered', async() => {
+    const loginPage = new LoginPage();
+    await loginPage.assertOnPage();
+});
+

--- a/tests/test-entry.sh
+++ b/tests/test-entry.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -xe
+
+TEST="testcafe chromium:headless  --no-sandbox --disable-dev-shm-usage "
+TEST_FIXTURE=${TEST_FIXTURE:-all}
+
+echo "Starting Test Suite: ${TEST_FIXTURE}"
+
+if [ ${TEST_FIXTURE} == "all" ]
+then
+  ${TEST} tests/**/*.browser.ts
+else
+  ${TEST} tests -F "${TEST_FIXTURE}*"
+fi
+


### PR DESCRIPTION
Setting the envvar "TEST_FIXTURE" will select only that named test fixture to run. Otherwise all the tests will run.

Closes #libero/reviewer#1067