### PR TITLE
fix: test-entry.sh glob

### DIFF
--- a/tests/test-entry.sh
+++ b/tests/test-entry.sh
@@ -8,7 +8,7 @@ echo "Starting Test Suite: ${TEST_FIXTURE}"
 
 if [ ${TEST_FIXTURE} == "all" ]
 then
-  ${TEST} tests/**/*.browser.ts
+  ${TEST} 'tests/**/*.browser.ts'
 else
   ${TEST} tests -F "${TEST_FIXTURE}*"
 fi


### PR DESCRIPTION
If passed a list of files testrunner appears to only run the first one.
This doesn't match the documentation...
By putting the glob in quotes the shell doesn't expand it.
Globbing is then handled by testcafe.