### PR TITLE
Redirect if token is invalid

### DIFF
--- a/src/login/utils/tokenUtils.ts
+++ b/src/login/utils/tokenUtils.ts
@@ -24,7 +24,7 @@ export const getToken = (): string => {
         // Token is expired. Remove it. exp is in seconds so convert to milliseconds.
         if (decodedToken.exp * 1000 < new Date().getTime()) {
             clearToken();
-            throw new Error('token invalid, clearing');
+            window.location.reload();
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/libero/reviewer/issues/1109

After review and consideration - this is the simplest solution that won't impact the code requiring a top level state or similar. This also happens to be the solution used for invalid tokens at the ApolloClient initialisation routine found here https://github.com/libero/reviewer-client/blob/master/src/core/utils/createApolloClient.ts#L44