### PR TITLE
Remove test due to js-dom limits

### DIFF
--- a/src/initial-submission/components/FileDetailsForm.test.tsx
+++ b/src/initial-submission/components/FileDetailsForm.test.tsx
@@ -115,27 +115,6 @@ describe('File Details Form', (): void => {
             expect(container.querySelector('#coverLetter .ProseMirror').textContent).toBe('');
         });
 
-        it.skip('should call the save mutation with correct variables when cover letter is changed', async (): Promise<
-            void
-        > => {
-            const { container } = render(
-                <FileDetailsForm
-                    schemaFactory={(): yup.ObjectSchema => yup.object()}
-                    initialValues={testInitialValues}
-                />,
-            );
-            fireEvent.change(container.querySelector('#coverLetter .ProseMirror'), {
-                target: { innerHTML: 'test cover letter input' },
-            });
-            await waitFor(() => {}, { timeout: 3000 });
-            expect(mutationMock).toBeCalledWith({
-                variables: {
-                    id: 'test',
-                    coverLetter: 'test cover letter input',
-                },
-            });
-        });
-
         it('shows validation message if left empty', async (): Promise<void> => {
             const { getByText } = render(
                 <FileDetailsForm


### PR DESCRIPTION
Based on this stack overflow (https://stackoverflow.com/questions/60495903/testing-react-contenteditable-with-react-testing-library+&cd=1&hl=en&ct=clnk&gl=uk) which points to two discussions https://github.com/testing-library/dom-testing-library/pull/235 and https://github.com/jsdom/jsdom/issues/1670

It’s not possible to simulate events on a contenteditable div within a js-dom context. This is a limit of js-dom itself. This is a known issue since 2016.

To save the test, the following was reviewed  - modifying the test to click the button but the value of the coverLetter would still be null as it requires that DOM event -> dispatchTranscation -> props.onChange to modify the state of coverLetter. 

Closes https://github.com/libero/reviewer/issues/1149