### PR TITLE
limit saucelabs to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,12 +53,12 @@ jobs:
       || github.ref == 'refs/heads/master'
     env:
       BROWSERS: >
-          'saucelabs:Firefox@latest:Windows 10',
-          'saucelabs:Chrome@latest:Windows 10',
-          'saucelabs:MicrosoftEdge@latest:Windows 10',
-          'saucelabs:Safari@13:macOS 10.13',
-          'saucelabs:Safari@12.0:macOS 10.14',
-          'saucelabs:Safari@11.0:macOS 10.12'
+          "saucelabs:Firefox@latest:Windows 10",
+          "saucelabs:Chrome@latest:Windows 10",
+          "saucelabs:MicrosoftEdge@latest:Windows 10",
+          "saucelabs:Safari@13:macOS 10.13",
+          "saucelabs:Safari@12.0:macOS 10.14",
+          "saucelabs:Safari@11.0:macOS 10.1"
       SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
       SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
       SAUCE_JOB: "reviewer-client"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Saucelabs Browsertests
-        run: yarn testcafe "${BROWSERS}" 'tests/**/*.browser.ts'
+        run: yarn testcafe ${BROWSERS} 'tests/**/*.browser.ts'
 
   browsertest-container:
     needs: [test, build]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,4 +146,3 @@ jobs:
           channel: libero-reviewer-tech
           status: FAILED
           color: danger
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,10 +80,15 @@ jobs:
           make start_ci_localhost
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Saucelabs Browsertests
+      - name: Windows Browsertests
         run: >
           yarn testcafe
-          "saucelabs:Firefox@latest:Windows 10","saucelabs:Chrome@latest:Windows 10","saucelabs:MicrosoftEdge@latest:Windows 10","saucelabs:Safari@13:macOS 10.13","saucelabs:Safari@12.0:macOS 10.14","saucelabs:Safari@11.0:macOS 10.12"
+          "saucelabs:Firefox@latest:Windows 10","saucelabs:Chrome@latest:Windows 10","saucelabs:MicrosoftEdge@latest:Windows 10"
+          'tests/**/*.browser.ts'
+      - name: Mac OS Browsertests
+        run: >
+          yarn testcafe
+          "saucelabs:Safari@13:macOS 10.13","saucelabs:Safari@12.0:macOS 10.14","saucelabs:Safari@11.0:macOS 10.12"
           'tests/**/*.browser.ts'
 
   browsertest-container:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
   notify-slack-if-master-fails:
+    needs: [test, build, saucelabs-tests, browsertest-and-push-images]
     runs-on: ubuntu-latest
     steps:
       - name: Notify slack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Saucelabs Browsertests
         run: >
           yarn testcafe
-          "saucelabs:Firefox@latest:Windows 10","saucelabs:Chrome@latest:Windows 10","saucelabs:MicrosoftEdge@latest:Windows 10","saucelabs:Safari@13:macOS 10.13","saucelabs:Safari@12.0:macOS 10.14","saucelabs:Safari@11.0:macOS 10.1"
+          "saucelabs:Firefox@latest:Windows 10","saucelabs:Chrome@latest:Windows 10","saucelabs:MicrosoftEdge@latest:Windows 10","saucelabs:Safari@13:macOS 10.13","saucelabs:Safari@12.0:macOS 10.14","saucelabs:Safari@11.0:macOS 10.12"
           'tests/**/*.browser.ts'
 
   browsertest-container:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,3 +146,4 @@ jobs:
           channel: libero-reviewer-tech
           status: FAILED
           color: danger
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,20 +47,18 @@ jobs:
   saucelabs-tests:
     needs: build
     runs-on: ubuntu-latest
-    if: "!contains(github.event.pull_request.body, '[skip-saucelabs]')"
-    strategy:
-      fail-fast: false
-      max-parallel: 4
-      matrix:
-        browser: [
+    # Only run if on master or if '[run-saucelabs]' is part of PR message
+    if: >
+      contains(github.event.pull_request.body, '[run-saucelabs]')
+      || github.ref == 'refs/heads/master'
+    env:
+      BROWSERS: >
           'saucelabs:Firefox@latest:Windows 10',
           'saucelabs:Chrome@latest:Windows 10',
           'saucelabs:MicrosoftEdge@latest:Windows 10',
           'saucelabs:Safari@13:macOS 10.13',
           'saucelabs:Safari@12.0:macOS 10.14',
           'saucelabs:Safari@11.0:macOS 10.12'
-          ]
-    env:
       SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
       SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
       SAUCE_JOB: "reviewer-client"
@@ -89,8 +87,8 @@ jobs:
           make start_ci_localhost
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: ${{ matrix.browser }}
-        run: yarn testcafe '${{ matrix.browser }}' 'tests/**/*.browser.ts'
+      - name: Saucelabs Browsertests
+        run: yarn testcafe "${BROWSERS}" 'tests/**/*.browser.ts'
 
   browsertest-container:
     needs: [test, build]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,13 +52,6 @@ jobs:
       contains(github.event.pull_request.body, '[run-saucelabs]')
       || github.ref == 'refs/heads/master'
     env:
-      BROWSERS: >
-          "saucelabs:Firefox@latest:Windows 10",
-          "saucelabs:Chrome@latest:Windows 10",
-          "saucelabs:MicrosoftEdge@latest:Windows 10",
-          "saucelabs:Safari@13:macOS 10.13",
-          "saucelabs:Safari@12.0:macOS 10.14",
-          "saucelabs:Safari@11.0:macOS 10.1"
       SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
       SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
       SAUCE_JOB: "reviewer-client"
@@ -88,7 +81,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Saucelabs Browsertests
-        run: yarn testcafe ${BROWSERS} 'tests/**/*.browser.ts'
+        run: >
+          yarn testcafe
+          "saucelabs:Firefox@latest:Windows 10",
+          "saucelabs:Chrome@latest:Windows 10",
+          "saucelabs:MicrosoftEdge@latest:Windows 10",
+          "saucelabs:Safari@13:macOS 10.13",
+          "saucelabs:Safari@12.0:macOS 10.14",
+          "saucelabs:Safari@11.0:macOS 10.1"
+          'tests/**/*.browser.ts'
 
   browsertest-container:
     needs: [test, build]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,3 +136,16 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+  notify-slack-if-master-fails:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify slack
+        if: failure() && github.ref == 'refs/heads/master'
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: libero-reviewer-tech
+          status: FAILED
+          color: danger

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,16 +80,12 @@ jobs:
           make start_ci_localhost
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Windows Browsertests
-        run: >
-          yarn testcafe
-          "saucelabs:Firefox@latest:Windows 10","saucelabs:Chrome@latest:Windows 10","saucelabs:MicrosoftEdge@latest:Windows 10"
-          'tests/**/*.browser.ts'
-      - name: Mac OS Browsertests
-        run: >
-          yarn testcafe
-          "saucelabs:Safari@13:macOS 10.13","saucelabs:Safari@12.0:macOS 10.14","saucelabs:Safari@11.0:macOS 10.12"
-          'tests/**/*.browser.ts'
+      - run: yarn testcafe "saucelabs:Firefox@latest:Windows 10"        'tests/**/*.browser.ts'
+      - run: yarn testcafe "saucelabs:Chrome@latest:Windows 10"         'tests/**/*.browser.ts'
+      - run: yarn testcafe "saucelabs:MicrosoftEdge@latest:Windows 10"  'tests/**/*.browser.ts'
+      - run: yarn testcafe "saucelabs:Safari@13:macOS 10.13"            'tests/**/*.browser.ts'
+      - run: yarn testcafe "saucelabs:Safari@12.0:macOS 10.14"          'tests/**/*.browser.ts'
+      - run: yarn testcafe "saucelabs:Safari@11.0:macOS 10.12"          'tests/**/*.browser.ts'
 
   browsertest-container:
     needs: [test, build]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,12 +83,7 @@ jobs:
       - name: Saucelabs Browsertests
         run: >
           yarn testcafe
-          "saucelabs:Firefox@latest:Windows 10",
-          "saucelabs:Chrome@latest:Windows 10",
-          "saucelabs:MicrosoftEdge@latest:Windows 10",
-          "saucelabs:Safari@13:macOS 10.13",
-          "saucelabs:Safari@12.0:macOS 10.14",
-          "saucelabs:Safari@11.0:macOS 10.1"
+          "saucelabs:Firefox@latest:Windows 10","saucelabs:Chrome@latest:Windows 10","saucelabs:MicrosoftEdge@latest:Windows 10","saucelabs:Safari@13:macOS 10.13","saucelabs:Safari@12.0:macOS 10.14","saucelabs:Safari@11.0:macOS 10.1"
           'tests/**/*.browser.ts'
 
   browsertest-container:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Browsertests will be run against SauceLabs for a variety of browsers but we also
 
 SauceLabs kindly grants us test capacity as part of their [OpenSauce](https://saucelabs.com/solutions/open-source) program.
 
-- disable saucelabs on a PR by adding `[skip-saucelabs]` to your PR description 
+- enable saucelabs on a PR by adding `[run-saucelabs]` to your PR description 
   - can't disable per commit because github [doesn't expose the commit message in its context](https://github.community/t/accessing-commit-message-in-pull-request-event/17158/2)
   - saucelabs job will always be run on commit/merge to master
 - browsers to run are set in `.github/workflows/ci.yml`


### PR DESCRIPTION
- only run saucelab tests if on 'master' or '[run-saucelabs]' is part of PR message
- alert #libero-reviewer-tech if pipeline fails on merge to master
- run tests in series as individual invocations of testcafe

Serial execution of the tests is necessary, as the testcafe saucelabs plugin's retry functionality does not behave as expected.
This has been recorded as a tech-debt issue: https://github.com/libero/reviewer/issues/1215

Closes: https://github.com/libero/reviewer/issues/1213