### PR TITLE
fix slack notify on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,15 @@ jobs:
       - run: yarn testcafe "saucelabs:Safari@13:macOS 10.13"            'tests/**/*.browser.ts'
       - run: yarn testcafe "saucelabs:Safari@12.0:macOS 10.14"          'tests/**/*.browser.ts'
       - run: yarn testcafe "saucelabs:Safari@11.0:macOS 10.12"          'tests/**/*.browser.ts'
+      - name: Notify slack on failure
+        if: failure() && github.ref == 'refs/heads/master'
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: libero-reviewer-tech
+          status: FAILED
+          color: danger
 
   browsertest-container:
     needs: [test, build]
@@ -133,13 +142,8 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-
-  notify-slack-if-master-fails:
-    needs: [test, build, saucelabs-tests, browsertest-and-push-images]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify slack
-        if: failure() && github.ref == 'refs/heads/master'
+      - name: Notify slack on failure
+        if: failure()
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1


### PR DESCRIPTION
Turns out github actions can't run be set up to run a job if other jobs fail... This should notify on failure in saucelabs or failure to push the image.