### PR TITLE
Error bar scroll issue on Safari

### DIFF
--- a/src/ui/atoms/Feedback.tsx
+++ b/src/ui/atoms/Feedback.tsx
@@ -16,7 +16,6 @@ const Feedback = (): JSX.Element => {
     const { message = undefined, error = undefined } = feedback;
 
     const handleScroll = (): void => {
-        console.log('ref.current', ref.current, error);
         if (ref.current) {
             window.pageYOffset > ref.current.getBoundingClientRect().bottom ? setSticky(true) : setSticky(false);
         }

--- a/src/ui/atoms/Feedback.tsx
+++ b/src/ui/atoms/Feedback.tsx
@@ -13,11 +13,11 @@ const Feedback = (): JSX.Element => {
     const { data } = useQuery(APPLICATION_ERROR);
     const { feedback = {} } = data && data.feedback ? data : {};
 
-    const { message = null, error = null } = feedback;
+    const { message = undefined, error = undefined } = feedback;
 
     const handleScroll = (): void => {
-        console.log('ref.current', ref.current);
-        if (ref.current && error) {
+        console.log('ref.current', ref.current, error);
+        if (ref.current) {
             window.pageYOffset > ref.current.getBoundingClientRect().bottom ? setSticky(true) : setSticky(false);
         }
     };
@@ -27,12 +27,12 @@ const Feedback = (): JSX.Element => {
         return (): void => {
             window.removeEventListener('scroll', () => handleScroll);
         };
-    }, [error]);
+    }, []);
 
     return (
         <React.Fragment>
-            {isSticky && <div className="fixed-padding" />}
-            <div className={`feedback ${error && 'error'} ${isSticky && 'stick'}`} ref={ref}>
+            {isSticky && error && <div className="fixed-padding" />}
+            <div className={`feedback ${error ? 'error' : 'hide'} ${isSticky ? 'stick' : ''}`} ref={ref}>
                 <div className="feedback__content">
                     <Interweave content={t(message)} />
                 </div>

--- a/src/ui/atoms/Feedback.tsx
+++ b/src/ui/atoms/Feedback.tsx
@@ -1,24 +1,25 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { useQuery, useMutation } from '@apollo/react-hooks';
+import { useQuery } from '@apollo/react-hooks';
 import { useTranslation } from 'react-i18next';
 import Interweave from 'interweave';
 
-import { CLEAR_ERROR, APPLICATION_ERROR } from '../../initial-submission/graphql';
+import { APPLICATION_ERROR } from '../../initial-submission/graphql';
 
 const Feedback = (): JSX.Element => {
     const { t } = useTranslation('ui');
     const [isSticky, setSticky] = useState(false);
-    const [clearError] = useMutation(CLEAR_ERROR);
     const ref = useRef(null);
-    const handleScroll = (): void => {
-        if (ref.current) {
-            window.scrollY > ref.current.getBoundingClientRect().bottom ? setSticky(true) : setSticky(false);
-        }
-    };
 
-    //eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const clearErrorHandler = async (): Promise<void> => {
-        await clearError();
+    const { data } = useQuery(APPLICATION_ERROR);
+    const { feedback = {} } = data && data.feedback ? data : {};
+
+    const { message = null, error = null } = feedback;
+
+    const handleScroll = (): void => {
+        console.log('ref.current', ref.current);
+        if (ref.current && error) {
+            window.pageYOffset > ref.current.getBoundingClientRect().bottom ? setSticky(true) : setSticky(false);
+        }
     };
 
     useEffect(() => {
@@ -26,16 +27,7 @@ const Feedback = (): JSX.Element => {
         return (): void => {
             window.removeEventListener('scroll', () => handleScroll);
         };
-    }, []);
-
-    const { data } = useQuery(APPLICATION_ERROR);
-
-    if (!data || !data.feedback) {
-        return <React.Fragment />;
-    }
-
-    // dismissable: indicates if this feedback can be dismissed. Parked pending styling discussion.
-    const { message, error } = data.feedback;
+    }, [error]);
 
     return (
         <React.Fragment>

--- a/src/ui/styles/Feedback.scss
+++ b/src/ui/styles/Feedback.scss
@@ -31,6 +31,10 @@
     }
 }
 
+.feedback.hide {
+    display: none;
+}
+
 .fixed-padding {
     height: 3rem;
 }


### PR DESCRIPTION
Closes https://github.com/libero/reviewer/issues/1402

The error seems to have been caused by a null ref. The simplest solution was to ensure the element exists and use css to hide it.