### PR TITLE
fix styling for table

### DIFF
--- a/src/static-pages/styles/required-info-table.scss
+++ b/src/static-pages/styles/required-info-table.scss
@@ -1,5 +1,7 @@
 .table-guide {
-    overflow-x: scroll;
+    @include forSize('tabletLandscapeDown') {
+      overflow-x: scroll;
+    }
 
     @include forSize('tabletPortraitDown') {
       max-width: calc(100vw - 6rem);
@@ -12,6 +14,16 @@
     table {
       border-collapse: collapse;
       border-spacing: 0;
+      margin-left: -10%;
+
+      @include forSize('desktopDown') {
+        margin-left: -20%;
+      }
+
+      @include forSize('tabletLandscapeDown') {
+        margin-left: 0;
+      }
+
       th {
         background-color: rgb(247, 247, 247);
         font-size: 0.75rem;
@@ -36,7 +48,7 @@
         border-image: initial;
       }
     }
-  
+
     ul {
       list-style: none;
       padding: 0;
@@ -44,5 +56,4 @@
         font-size: 0.813rem;
       }
     }
-  
-  }
+}

--- a/src/static-pages/styles/static-page.scss
+++ b/src/static-pages/styles/static-page.scss
@@ -1,5 +1,4 @@
 .static-page {
-    overflow: hidden;
     grid-row: 2;
     grid-column: 4 / span 6;
     @include forSize('desktopDown') {


### PR DESCRIPTION
Closes libero/reviewer#1438 

This will reintroduce libero/reviewer#1440 due to a strange bug where chrome applies overflow-y on the x axis of a grid column.