### PR TITLE
Add longer timeouts to integration points

### DIFF
--- a/tests/page-objects/EditorPage.ts
+++ b/tests/page-objects/EditorPage.ts
@@ -36,7 +36,8 @@ export class EditorPage {
     private readonly maxReviewingEditors = 6;
 
     public async assertOnPage(): Promise<void> {
-        await t.expect(this.editorsStep.exists).ok();
+        // long timeout accounts for e2e people api call delays
+        await t.expect(this.editorsStep.exists).ok({ timeout: 30000 });
         await t.expect(this.seniorEditorsPicker.exists).ok();
         await t.expect(this.suggestedReviewingEditorsPicker.exists).ok();
         await t.expect(this.nextButton.exists).ok();

--- a/tests/page-objects/FilesPage.ts
+++ b/tests/page-objects/FilesPage.ts
@@ -131,7 +131,8 @@ export class FilesPage {
 
     public async uploadManuscriptFile(filePath: string): Promise<void> {
         await t.setFilesToUpload(this.manuscriptInput, filePath);
-        await t.expect(this.manuscriptReplaceButton.withText('Replace').exists).ok();
+        // long timeout accounts for e2e s3/sciencebeam delay
+        await t.expect(this.manuscriptReplaceButton.withText('Replace').exists).ok({ timeout: 30000 });
         await t.expect(this.manuscriptReplaceButton.withText('Replace').visible).ok();
     }
 


### PR DESCRIPTION
Attempt to fix e2e test failures when asserting on external call responses.