### PR TITLE
fix: static text updates in the editors section of the initial submission wizard

### DIFF
--- a/public/locales/en/wizard-form.json
+++ b/public/locales/en/wizard-form.json
@@ -71,6 +71,9 @@
     },
     "editors": {
         "title": "Who should review your work?",
+        "subtitle_1": "All suggestions for editors and reviewers should not have any competing interests with respect to authors or the submission. See ",
+        "subtitle-link": "eLife’s competing interests policy",
+        "subtitle_2": " for more information.",
         "editors-people-picker-label": "Suggest Senior Editors",
         "reviewers-people-picker-label": "Suggest Reviewing Editors",
         "reviewers-title": "Suggest Reviewers (Optional)",

--- a/src/initial-submission/components/EditorsForm.tsx
+++ b/src/initial-submission/components/EditorsForm.tsx
@@ -195,6 +195,13 @@ const EditorsForm = ({ initialValues, schemaFactory, ButtonComponent, toggleErro
     return (
         <div className="editors-step">
             <h2 className="typography__heading typography__heading--h2 files-step__title">{t('editors.title')}</h2>
+            <div className="typography__body typography__body--secondary">
+                {t('editors.subtitle_1')}
+                <Link to="/author-guide/journal-policies#competing-interests" className="typography__body--link">
+                    {t('editors.subtitle-link')}
+                </Link>
+                {t('editors.subtitle_2')}
+            </div>
             <PeoplePicker
                 label={t('editors.editors-people-picker-label')}
                 people={


### PR DESCRIPTION
Updated various pieces of text in the submission wizard as per the Editorial teams requirements.