### PR TITLE
fix: date utc flag that works on linux and mac os

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DOCKER_COMPOSE_CI = IMAGE_TAG=${IMAGE_TAG} docker-compose -f docker-compose.ci.y
 DOCKER_COMPOSE_BUILD = IMAGE_TAG=${IMAGE_TAG} docker-compose -f docker-compose.build.yml
 
 export SAUCE_JOB=reviewer-client
-export SAUCE_BUILD ?= "local-$(shell date --utc +%Y%m%d.%H%M)"
+export SAUCE_BUILD ?= "local-$(shell date -u +%Y%m%d.%H%M)"
 export SAUCE_API_HOST=eu-central-1.saucelabs.com
 
 help:


### PR DESCRIPTION
On mac, the following produces an error:

```
$ date --utc +%Y%m%d.%H%M
date: illegal option -- -
usage: date [-jnRu] [-d dst] [-r seconds] [-t west] [-v[+|-]val[ymwdHMS]] ...
            [-f fmt date | [[[mm]dd]HH]MM[[cc]yy][.ss]] [+format]
```

I believe the `--utc` flag can be exchanged for `-u` and work in both environments.

```
$ date -u +%Y%m%d.%H%M
20210319.0943
```