### PR TITLE
Pin testcafe dep and image version

### DIFF
--- a/browsertests.Dockerfile
+++ b/browsertests.Dockerfile
@@ -1,7 +1,6 @@
-FROM testcafe/testcafe
+FROM testcafe/testcafe:1.14.2
 
 WORKDIR /app
-
 
 USER root
 RUN npm install testcafe-react-selectors testcafe

--- a/browsertests.Dockerfile
+++ b/browsertests.Dockerfile
@@ -1,9 +1,9 @@
-FROM testcafe/testcafe:1.13.0
+FROM testcafe/testcafe:1.14.2
 
 WORKDIR /app
 
 USER root
-RUN npm install testcafe-react-selectors testcafe@1.13.0
+RUN npm install testcafe-react-selectors testcafe@1.14.2
 USER user
 
 

--- a/browsertests.Dockerfile
+++ b/browsertests.Dockerfile
@@ -2,6 +2,7 @@ FROM testcafe/testcafe
 
 WORKDIR /app
 
+
 USER root
 RUN npm install testcafe-react-selectors testcafe
 USER user

--- a/browsertests.Dockerfile
+++ b/browsertests.Dockerfile
@@ -1,4 +1,4 @@
-FROM testcafe/testcafe:1.14.2
+FROM testcafe/testcafe:1.14.1
 
 WORKDIR /app
 

--- a/browsertests.Dockerfile
+++ b/browsertests.Dockerfile
@@ -1,9 +1,9 @@
-FROM testcafe/testcafe:1.14.1
+FROM testcafe/testcafe:1.13.0
 
 WORKDIR /app
 
 USER root
-RUN npm install testcafe-react-selectors testcafe
+RUN npm install testcafe-react-selectors testcafe@1.13.0
 USER user
 
 


### PR DESCRIPTION
A recent testcafe release (either official docker image or the dependency itself) has caused issues with running the `--no-sandbox` argument on `master`. This PR pins the two to `testcafe:1.14.2` 