### PR TITLE
fix: cookiebot is blocking the login page from loading

### DIFF
--- a/browsertests.Dockerfile
+++ b/browsertests.Dockerfile
@@ -1,9 +1,9 @@
-FROM testcafe/testcafe:1.14.2
+FROM testcafe/testcafe:1.15.2
 
 WORKDIR /app
 
 USER root
-RUN npm install testcafe-react-selectors testcafe@1.14.2
+RUN npm install testcafe-react-selectors testcafe@1.15.2
 USER user
 
 

--- a/browsertests.Dockerfile
+++ b/browsertests.Dockerfile
@@ -3,7 +3,7 @@ FROM testcafe/testcafe:1.15.2
 WORKDIR /app
 
 USER root
-RUN npm install testcafe-react-selectors testcafe@1.15.2
+RUN npm install testcafe-react-selectors@4.1.5 testcafe@1.15.2
 USER user
 
 

--- a/public/index.html
+++ b/public/index.html
@@ -3,18 +3,18 @@
 
 <head>
   <!-- CookieBot Code-->
-  <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="0a5c50d8-fcf9-47b1-8f4f-1eaadb13941b" data-blockingmode="auto" type="text/javascript"></script>
+  <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="0a5c50d8-fcf9-47b1-8f4f-1eaadb13941b" type="text/javascript"></script>
 
   <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-176153230-1"></script>
-  <script>
+  <script type="text/plain" data-cookieconsent="statistics" async src="https://www.googletagmanager.com/gtag/js?id=UA-176153230-1"></script>
+  <script type="text/plain" data-cookieconsent="statistics">
     window.dataLayer = window.dataLayer || [];
     function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
     gtag('config', 'UA-176153230-1');
   </script>
   <!-- Hotjar Tracking Code for https://reviewer.elifesciences.org -->
-  <script>
+  <script type="text/plain" data-cookieconsent="statistics">
     (function(h,o,t,j,a,r){
         h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
         h._hjSettings={hjid:443270,hjsv:6};

--- a/public/index.html
+++ b/public/index.html
@@ -6,15 +6,15 @@
   <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="0a5c50d8-fcf9-47b1-8f4f-1eaadb13941b" type="text/javascript"></script>
 
   <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script type="text/plain" data-cookieconsent="statistics" async src="https://www.googletagmanager.com/gtag/js?id=UA-176153230-1"></script>
-  <script type="text/plain" data-cookieconsent="statistics">
+  <script type="text/plain" data-cookieconsent="statistics,marketing" async src="https://www.googletagmanager.com/gtag/js?id=UA-176153230-1"></script>
+  <script type="text/plain" data-cookieconsent="statistics,marketing">
     window.dataLayer = window.dataLayer || [];
     function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
     gtag('config', 'UA-176153230-1');
   </script>
   <!-- Hotjar Tracking Code for https://reviewer.elifesciences.org -->
-  <script type="text/plain" data-cookieconsent="statistics">
+  <script type="text/plain" data-cookieconsent="statistics,marketing">
     (function(h,o,t,j,a,r){
         h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
         h._hjSettings={hjid:443270,hjsv:6};


### PR DESCRIPTION
Cookiebot has a feature that automatically scans the site on a monthly frequency and determines which scripts it should block. Since the most recent scan at the start of october, it's started to incorrectly block some scripts and as such the page fails to load until the banner is dismissed. [We're not the only ones caught out by this](https://support.cookiebot.com/hc/en-us/community/posts/360007744680-Cookiebot-blocks-every-script-on-website?page=2#comments), and doesn't paint Cookiebot that well as a stable solution.
I've updated the code to rely on [manually marking the scripts against the consent topics that they relate to](https://www.cookiebot.com/en/manual-implementation/), which resolved the issue with the banner and got the CookieBot tests passing again.
This then surfaced [another issue](https://github.com/DevExpress/testcafe-hammerhead/issues/2653), an unhandled HTTP2 exception from within TestCafe which was resolved by updating to v1.15.2.
Finally, I pinned down a floating dependency to hopefully keep things more consistent.