### PR TITLE
fix: run each test suite as a seperate run in saucelabs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,9 @@ jobs:
           make start_ci_localhost
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - run: find ./tests -name *.browser.ts -type f | xargs yarn testcafe --sf --assertion-timeout 15000 --skip-js-errors "saucelabs:Firefox@latest:Windows 10"
-      - run: find ./tests -name *.browser.ts -type f | xargs yarn testcafe --sf --assertion-timeout 15000 --skip-js-errors "saucelabs:MicrosoftEdge@latest:Windows 10"
-      - run: find ./tests -name *.browser.ts -type f | xargs yarn testcafe --sf --assertion-timeout 15000 --skip-js-errors "saucelabs:Safari@13:macOS 10.13"
+      - run: find ./tests -name *.browser.ts -type f | xargs -I % yarn testcafe --sf --assertion-timeout 15000 --skip-js-errors "saucelabs:Firefox@latest:Windows 10" %
+      - run: find ./tests -name *.browser.ts -type f | xargs -I % yarn testcafe --sf --assertion-timeout 15000 --skip-js-errors "saucelabs:MicrosoftEdge@latest:Windows 10" %
+      - run: find ./tests -name *.browser.ts -type f | xargs -I % yarn testcafe --sf --assertion-timeout 15000 --skip-js-errors "saucelabs:Safari@13:macOS 10.13" %
       - name: Dump logs on failure
         if: failure()
         run: |


### PR DESCRIPTION
Tests on SauceLabs have a hard limit of 30 minutes, and in some runs our suites take just over this to complete and hence fail. This change runs each suite separately, and hence resolves the issue.

[run-saucelabs]