### PR TITLE
change id to match new cookie banner button id

### DIFF
--- a/test-utils/cookieBanner.ts
+++ b/test-utils/cookieBanner.ts
@@ -1,7 +1,7 @@
 import { Selector, t } from 'testcafe';
 
 const cookieBanner: Selector = Selector('#CybotCookiebotDialog');
-const cookieBannerButton: Selector = Selector('#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll');
+const cookieBannerButton: Selector = Selector('#CybotCookiebotDialogBodyLevelButtonAccept');
 
 export async function dismissCookieBanner(): Promise<void> {
     if (await cookieBanner.exists) {


### PR DESCRIPTION
Cookie banner has been changed externally so the new id is required for the tests to pass.